### PR TITLE
central upload button fixed

### DIFF
--- a/lib/Screens/upload_pic_screen.dart
+++ b/lib/Screens/upload_pic_screen.dart
@@ -41,31 +41,49 @@ class _UploadPicScreenState extends State<UploadPicScreen> {
                   borderRadius: BorderRadius.circular(20),
                   border: Border.all(color: splashScreen, width: 2),
                 ),
-                child: _selectedImage == null
-                    ? Center(
-                        child: IconButton(
-                          onPressed: () async {
-                            FilePickerResult? result =
-                                await FilePicker.platform.pickFiles(
-                              type: FileType.custom,
-                              allowedExtensions: ['png', 'jpeg', 'jpg'],
-                            );
-                            if (result != null && result.files.single.path != null){
-                              setState(() {
-                                _selectedImage = File(result.files.single.path!);
-                              });
-                            }
-                          },
-                          icon: const Icon(Icons.add_a_photo),
+                child: GestureDetector(
+                  onTap: () async {
+                    FilePickerResult? result =
+                        await FilePicker.platform.pickFiles(
+                      type: FileType.custom,
+                      allowedExtensions: ['png', 'jpeg', 'jpg'],
+                    );
+                    if (result != null && result.files.single.path != null) {
+                      setState(() {
+                        _selectedImage = File(result.files.single.path!);
+                      });
+                    }
+                  },
+                  child: _selectedImage == null
+                      ? Center(
+                          child: IconButton(
+                            onPressed: () async {
+                              FilePickerResult? result =
+                                  await FilePicker.platform.pickFiles(
+                                type: FileType.custom,
+                                allowedExtensions: ['png', 'jpeg', 'jpg'],
+                              );
+                              if (result != null &&
+                                  result.files.single.path != null) {
+                                setState(() {
+                                  _selectedImage =
+                                      File(result.files.single.path!);
+                                });
+                              }
+                            },
+                            icon: const Icon(Icons.add_a_photo),
+                          ),
+                        )
+                      : ClipRRect(
+                          borderRadius: BorderRadius.circular(20),
+                          child: Image.file(
+                            _selectedImage!,
+                            fit: BoxFit.cover,
+                            width: 298,
+                            height: 297,
+                          ),
                         ),
-                      )
-                    : ClipRRect(
-                        borderRadius: BorderRadius.circular(20),
-                        child: Image.file(
-                          _selectedImage!,
-                          fit: BoxFit.cover,
-                        ),
-                      ),
+                ),
               ),
             ),
             const SizedBox(height: 10),


### PR DESCRIPTION
The feature to reupload another image to the central box was not working. Wrapped entire widget with a GestureDetector.

https://github.com/user-attachments/assets/f78635b2-97ff-4a37-b501-45de33d4962b

